### PR TITLE
Throw exception on invalid expression instead of giving PHP error

### DIFF
--- a/src/Exception/InvalidExpression.php
+++ b/src/Exception/InvalidExpression.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace LangleyFoxall\MathEval\Exception;
+
+use RuntimeException;
+
+class InvalidExpression extends RuntimeException
+{
+}

--- a/src/MathEvaluator.php
+++ b/src/MathEvaluator.php
@@ -2,6 +2,7 @@
 
 namespace LangleyFoxall\MathEval;
 
+use LangleyFoxall\MathEval\Exception\InvalidExpression;
 use MathParser\Interpreting\Evaluator;
 use MathParser\StdMathParser;
 
@@ -33,10 +34,14 @@ class MathEvaluator
 
     /**
      * @return mixed
+     * @throws InvalidExpression
      */
     public function evaluate()
     {
         $abstractSyntaxTree = $this->parse();
+        if ($abstractSyntaxTree === null) {
+            throw new InvalidExpression(sprintf('The given expression "%s" could not be evaluated', $this->expression));
+        }
 
         $evaluator = new Evaluator();
 

--- a/tests/Unit/EvaluationsTest.php
+++ b/tests/Unit/EvaluationsTest.php
@@ -2,6 +2,7 @@
 
 namespace LangleyFoxall\MathEval\Tests\Unit;
 
+use LangleyFoxall\MathEval\Exception\InvalidExpression;
 use PHPUnit\Framework\TestCase;
 
 class EvaluationsTest extends TestCase
@@ -23,5 +24,11 @@ class EvaluationsTest extends TestCase
     public function testEvaluation($expression, $expectedResult)
     {
         $this->assertEquals($expectedResult, math_eval($expression));
+    }
+
+    public function testEvaluationInvalidExpressionThrows()
+    {
+        $this->expectException(InvalidExpression::class);
+        math_eval(' + ');
     }
 }


### PR DESCRIPTION
When `math_eval()` is given an invalid math expression, the `MathParser` package returns a `null` AST. This PR changes the behaviour by throwing an `InvalidExpression` exception instead which make it catchable.